### PR TITLE
Use 3.14 as cmake_minimum_required

### DIFF
--- a/speak_ros/CMakeLists.txt
+++ b/speak_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(speak_ros)
 
 find_package(ament_cmake_auto REQUIRED)

--- a/speak_ros_interfaces/CMakeLists.txt
+++ b/speak_ros_interfaces/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(speak_ros_interfaces)
 
 find_package(ament_cmake_auto REQUIRED)


### PR DESCRIPTION
To avoid warning lie below

```bash
CMake Deprecation Warning at /opt/ros/jazzy/src/gtest_vendor/CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```

3.14 is the lowest version for available ROS 2 distributions