### PR TITLE
Fix build errors on rolling

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push:
   pull_request:
   workflow_dispatch: # allow manually starting this workflow
 

--- a/speak_ros_aivis_plugin/CMakeLists.txt
+++ b/speak_ros_aivis_plugin/CMakeLists.txt
@@ -6,37 +6,14 @@ find_package(cpprestsdk REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
-target_include_directories(${PROJECT_NAME} PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
 
 target_link_libraries(${PROJECT_NAME} cpprestsdk::cpprest)
 
 pluginlib_export_plugin_description_file(speak_ros plugins.xml)
-
-
-install(
-  TARGETS ${PROJECT_NAME}
-  EXPORT export_${PROJECT_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_libraries(
-  ${PROJECT_NAME}
-)
-ament_export_targets(
-  export_${PROJECT_NAME}
-)
-
-if($ENV{ROS_DISTRO} STREQUAL "humble" OR $ENV{ROS_DISTRO} STREQUAL "jazzy")
-  ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)
-else()
-  ament_auto_package()
-endif()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/speak_ros_aivis_plugin/CMakeLists.txt
+++ b/speak_ros_aivis_plugin/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(speak_ros_aivis_plugin)
 
 find_package(ament_cmake_auto REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(cpprestsdk REQUIRED)
 ament_auto_find_build_dependencies()
 

--- a/speak_ros_aivis_plugin/CMakeLists.txt
+++ b/speak_ros_aivis_plugin/CMakeLists.txt
@@ -2,20 +2,13 @@ cmake_minimum_required(VERSION 3.5)
 project(speak_ros_aivis_plugin)
 
 find_package(ament_cmake_auto REQUIRED)
-find_package(ament_cmake REQUIRED)
 find_package(cpprestsdk REQUIRED)
 ament_auto_find_build_dependencies()
 
-add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
+ament_auto_add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-
-ament_target_dependencies(${PROJECT_NAME}
-  rclcpp
-  speak_ros
-  pluginlib
-)
 
 target_link_libraries(${PROJECT_NAME} cpprestsdk::cpprest)
 

--- a/speak_ros_aivis_plugin/package.xml
+++ b/speak_ros_aivis_plugin/package.xml
@@ -9,6 +9,7 @@
 
   <license>Apache 2.0</license>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>libcpprest-dev</depend>

--- a/speak_ros_interfaces/package.xml
+++ b/speak_ros_interfaces/package.xml
@@ -9,7 +9,7 @@
 
     <license>Apache 2.0</license>
 
-    <buildtool_depend>ament_cmake_auto</buildtool_depend>s
+    <buildtool_depend>ament_cmake_auto</buildtool_depend>
     <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
     <exec_depend>rosidl_default_runtime</exec_depend>

--- a/speak_ros_open_jtalk_plugin/CMakeLists.txt
+++ b/speak_ros_open_jtalk_plugin/CMakeLists.txt
@@ -5,31 +5,12 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
-target_include_directories(${PROJECT_NAME} PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
 
 pluginlib_export_plugin_description_file(speak_ros plugins.xml)
-
-
-install(
-  TARGETS ${PROJECT_NAME}
-  EXPORT export_${PROJECT_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_libraries(
-  ${PROJECT_NAME}
-)
-ament_export_targets(
-  export_${PROJECT_NAME}
-)
-
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/speak_ros_open_jtalk_plugin/CMakeLists.txt
+++ b/speak_ros_open_jtalk_plugin/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(speak_ros_open_jtalk_plugin)
 
 find_package(ament_cmake_auto REQUIRED)
+find_package(ament_cmake REQUIRED)
 ament_auto_find_build_dependencies()
 
 add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)

--- a/speak_ros_open_jtalk_plugin/CMakeLists.txt
+++ b/speak_ros_open_jtalk_plugin/CMakeLists.txt
@@ -2,19 +2,12 @@ cmake_minimum_required(VERSION 3.5)
 project(speak_ros_open_jtalk_plugin)
 
 find_package(ament_cmake_auto REQUIRED)
-find_package(ament_cmake REQUIRED)
 ament_auto_find_build_dependencies()
 
-add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
+ament_auto_add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-
-ament_target_dependencies(${PROJECT_NAME}
-  rclcpp
-  speak_ros
-  pluginlib
-)
 
 pluginlib_export_plugin_description_file(speak_ros plugins.xml)
 

--- a/speak_ros_open_jtalk_plugin/package.xml
+++ b/speak_ros_open_jtalk_plugin/package.xml
@@ -9,7 +9,8 @@
 
     <license>Apache 2.0</license>
 
-    <buildtool_depend>ament_cmake_auto</buildtool_depend>s
+    <buildtool_depend>ament_cmake</buildtool_depend>
+    <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
     <depend>speak_ros</depend>
     <depend>rclcpp</depend>

--- a/speak_ros_openai_tts_plugin/CMakeLists.txt
+++ b/speak_ros_openai_tts_plugin/CMakeLists.txt
@@ -6,37 +6,14 @@ find_package(cpprestsdk REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
-target_include_directories(${PROJECT_NAME} PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
 
 target_link_libraries(${PROJECT_NAME} cpprestsdk::cpprest)
 
 pluginlib_export_plugin_description_file(speak_ros plugins.xml)
-
-
-install(
-  TARGETS ${PROJECT_NAME}
-  EXPORT export_${PROJECT_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_libraries(
-  ${PROJECT_NAME}
-)
-ament_export_targets(
-  export_${PROJECT_NAME}
-)
-
-if($ENV{ROS_DISTRO} STREQUAL "humble" OR $ENV{ROS_DISTRO} STREQUAL "jazzy")
-  ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)
-else()
-  ament_auto_package()
-endif()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/speak_ros_openai_tts_plugin/CMakeLists.txt
+++ b/speak_ros_openai_tts_plugin/CMakeLists.txt
@@ -2,20 +2,13 @@ cmake_minimum_required(VERSION 3.14)
 project(speak_ros_openai_tts_plugin)
 
 find_package(ament_cmake_auto REQUIRED)
-find_package(ament_cmake REQUIRED)
 find_package(cpprestsdk REQUIRED)
 ament_auto_find_build_dependencies()
 
-add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
+ament_auto_add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-
-ament_target_dependencies(${PROJECT_NAME}
-  rclcpp
-  speak_ros
-  pluginlib
-)
 
 target_link_libraries(${PROJECT_NAME} cpprestsdk::cpprest)
 

--- a/speak_ros_openai_tts_plugin/CMakeLists.txt
+++ b/speak_ros_openai_tts_plugin/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 project(speak_ros_openai_tts_plugin)
 
 find_package(ament_cmake_auto REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(cpprestsdk REQUIRED)
 ament_auto_find_build_dependencies()
 

--- a/speak_ros_openai_tts_plugin/package.xml
+++ b/speak_ros_openai_tts_plugin/package.xml
@@ -9,6 +9,7 @@
 
     <license>Apache 2.0</license>
 
+    <buildtool_depend>ament_cmake</buildtool_depend>
     <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
     <depend>speak_ros</depend>

--- a/speak_ros_voicevox_plugin/CMakeLists.txt
+++ b/speak_ros_voicevox_plugin/CMakeLists.txt
@@ -6,37 +6,14 @@ find_package(cpprestsdk REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
-target_include_directories(${PROJECT_NAME} PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
 
 target_link_libraries(${PROJECT_NAME} cpprestsdk::cpprest)
 
 pluginlib_export_plugin_description_file(speak_ros plugins.xml)
-
-
-install(
-  TARGETS ${PROJECT_NAME}
-  EXPORT export_${PROJECT_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_libraries(
-  ${PROJECT_NAME}
-)
-ament_export_targets(
-  export_${PROJECT_NAME}
-)
-
-if($ENV{ROS_DISTRO} STREQUAL "humble" OR $ENV{ROS_DISTRO} STREQUAL "jazzy")
-  ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)
-else()
-  ament_auto_package()
-endif()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/speak_ros_voicevox_plugin/CMakeLists.txt
+++ b/speak_ros_voicevox_plugin/CMakeLists.txt
@@ -2,20 +2,13 @@ cmake_minimum_required(VERSION 3.5)
 project(speak_ros_voicevox_plugin)
 
 find_package(ament_cmake_auto REQUIRED)
-find_package(ament_cmake REQUIRED)
 find_package(cpprestsdk REQUIRED)
 ament_auto_find_build_dependencies()
 
-add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
+ament_auto_add_library(${PROJECT_NAME} SHARED src/${PROJECT_NAME}.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-
-ament_target_dependencies(${PROJECT_NAME}
-  rclcpp
-  speak_ros
-  pluginlib
-)
 
 target_link_libraries(${PROJECT_NAME} cpprestsdk::cpprest)
 

--- a/speak_ros_voicevox_plugin/CMakeLists.txt
+++ b/speak_ros_voicevox_plugin/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(speak_ros_voicevox_plugin)
 
 find_package(ament_cmake_auto REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(cpprestsdk REQUIRED)
 ament_auto_find_build_dependencies()
 

--- a/speak_ros_voicevox_plugin/package.xml
+++ b/speak_ros_voicevox_plugin/package.xml
@@ -9,6 +9,7 @@
 
     <license>Apache 2.0</license>
 
+    <buildtool_depend>ament_cmake</buildtool_depend>
     <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
     <depend>speak_ros</depend>


### PR DESCRIPTION
On ROS 2 rolling, ament_target_dependencies is deleted

https://github.com/ament/ament_cmake/pull/614